### PR TITLE
Fixed a couple of very small spelling mistakes.

### DIFF
--- a/Ultrasonic/Ultrasonic.cpp
+++ b/Ultrasonic/Ultrasonic.cpp
@@ -47,8 +47,8 @@ long Ultrasonic::Ranging(int sys)
 {
   Timing();
   if (sys) {
-	distacne_cm = duration /29 / 2 ;
-	return distacne_cm;
+	distance_cm = duration /29 / 2 ;
+	return distance_cm;
   } else {
 	distance_inc = duration / 74 / 2;
 	return distance_inc; }

--- a/Ultrasonic/Ultrasonic.h
+++ b/Ultrasonic/Ultrasonic.h
@@ -28,7 +28,7 @@ class Ultrasonic
     int Trig_pin;
     int Echo_pin;
 	long Time_out;
-    long duration,distacne_cm,distance_inc;
+    long duration,distance_cm,distance_inc;
 };
 
 #endif


### PR DESCRIPTION
When I was reviewing this code, I caught what I initially thought was a bug in the code. . . until I realized it was a small spelling mistake that had been made consistently in a specific variable name. This pull request simply fixes the spelling to keep distance_cm consistent with distance_inc. Thanks for your work!
